### PR TITLE
Add rollup plugin for HubL cleanup step and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # postcss-hubl syntax
 
-## Purpose 
+## Purpose
 
 Allows hubl expressions and hubl statements to be used in their native form in webpack builds.
 
 ## What is included?
 
-This is a postcss syntax as specified by the postcss documentation [here](https://github.com/postcss/postcss/blob/main/docs/syntax.md). 
+This is a postcss syntax as specified by the postcss documentation [here](https://github.com/postcss/postcss/blob/main/docs/syntax.md).
 
 It contains 4 main pieces:
 
 - Parser
 - Stringifier
 - Tokenizer
-- hubl-clean plugin
+- hubl-clean plugin or rollup-plugin-hubl-cleaner
 
 All of which are extensions of their respective base postcss counterparts.
 
@@ -23,7 +23,7 @@ All of which are extensions of their respective base postcss counterparts.
 ## Usage
 
 ### Add postcss-hubl to postcss
-Tell post css to use hubl-parser. During the compile process this will wrap all of your hubl in a special comment. This is necessary to keep valid css so that any other linters and tools that you use in your build process will still work. 
+Tell post css to use hubl-parser. During the compile process this will wrap all of your hubl in a special comment. This is necessary to keep valid css so that any other linters and tools that you use in your build process will still work.
 **postcss.config.js**
 ```js {title: postcss.config.js}
 const HublParser = require('@spingroup/postcss-hubl/hubl-parse');
@@ -34,9 +34,12 @@ module.exports = {
 };
 ```
 
-### Use hubl-clean plugin
+### Use hubl-clean plugin - webpack or vite support
 
-The last step is to add the hubl-clean plugin to webpack.config.js. This plugin fires after webpack has finished compiling assets (after your other build tools have finished running) and will remove the comments from your hubl. You can then upload your dist directory to hubspot. 
+The last step is to add the appropriate `webpack` or `vite` cleanup plugin. This plugin fires after your build tool has finished compiling assets (after your other build tools have finished running) and will remove the comments from your HubL. You can then upload your dist directory to HubSpot.
+
+
+#### To configure `webpack`:
 
 **webpack.config.js**
 ```js {title: postcss.config.js}
@@ -48,6 +51,22 @@ module.exports = {
   ]
 };
 ```
+
+#### To configure `vite`:
+
+**vite.config.ts**
+```js {title: vite.config.ts}
+
+import HublPostCSSCleaner from '@spingroup/postcss-hubl/rollup-plugin-hubl-cleaner';
+
+export default defineConfig({
+  plugins: [
+    new HublPostCSSCleaner(),
+  ]
+  ...
+});
+```
+
 
 **Styles.css Input**
 ```css {title: postcss.config.js}
@@ -70,7 +89,7 @@ module.exports = {
 
 **Styles.css output after HublClean**
 ```css {title: postcss.config.js}
-{% if x %} 
+{% if x %}
 .test-selector {
   display: {{module.test_display}};
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "hubspot",
     "hubl",
     "webpack",
+    "vite",
     "postcss",
     "postcss-hubl",
     "spingroup"

--- a/rollup-plugin-hubl-cleaner/index.js
+++ b/rollup-plugin-hubl-cleaner/index.js
@@ -1,0 +1,15 @@
+/**
+ * A rollup plugin to remove comment tokens added by postcss-hubl.
+ *
+ * https://github.com/spingroup/postcss-hubl
+ */
+export default function HublPostCSSCleaner () {
+  return {
+    name: 'hubl-cleaner', // this name will show up in logs and errors
+    transform(source, id) {
+      // Remove all comment keys from start and end
+      // /*~| and |~*/
+      return source.replace(/(\/\*\~\|)/g, "").replace(/(\|\~\*\/)/g, "")
+    },
+  };
+}


### PR DESCRIPTION
To use this post-css plugin with `vite` the cleanup step needs to be a rollup plugin. This includes it and updates the documentation.